### PR TITLE
2.0.13

### DIFF
--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -180,6 +180,7 @@ export interface Check {
   approvedBy: number | null;
   notificationId: number | null;
   communityNoteNotificationId: number | null;
+  isReport: boolean;
 }
 
 export interface Submission {

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -78,6 +78,7 @@ interface BaseAgentRequest {
   model?: string;
   consumerName?: string;
   findSimilar?: boolean;
+  isReport?: boolean;
 }
 
 // Text-only request

--- a/workers/agent-service/src/agent.ts
+++ b/workers/agent-service/src/agent.ts
@@ -876,6 +876,7 @@ export class CheckerAgent extends DurableObject<Env> {
                 caption: this.caption ?? null,
                 longformResponse: longformReport,
                 shortformResponse: communityNote,
+                isReport: request.isReport ?? false,
               }),
             }),
           );

--- a/workers/agent-service/src/agent.ts
+++ b/workers/agent-service/src/agent.ts
@@ -518,6 +518,7 @@ export class CheckerAgent extends DurableObject<Env> {
             approvedBy: null,
             notificationId: null,
             communityNoteNotificationId: null,
+            isReport: request.isReport ?? false,
           },
           id, // Pass the ObjectId to use as the document _id
         );

--- a/workers/ai-checker-service/src/lib/create-check.ts
+++ b/workers/ai-checker-service/src/lib/create-check.ts
@@ -104,6 +104,9 @@ export async function createCheck(
         isVoteTriggered: false,
         isApprovedForPublishing: false,
         approvedBy: null,
+        notificationId: null,
+        communityNoteNotificationId: null,
+        isReport: request.isReport ?? false,
       },
       id
     );

--- a/workers/api-entrypoint/src/endpoints/agentCheck.ts
+++ b/workers/api-entrypoint/src/endpoints/agentCheck.ts
@@ -37,6 +37,7 @@ export const agentRequestSchema = {
             // Common properties
             model: z.string().optional(),
             findSimilar: z.boolean().optional(),
+            isReport: z.boolean().optional(),
           })
           .describe(
             "Request body schema. For text, pass 'text' only. For image, pass 'imageUrl' or 'caption'. Leave 'model' blank for default."
@@ -81,6 +82,7 @@ export async function handleAgentRequest(
       caption?: string | null;
       model?: string;
       findSimilar?: boolean;
+      isReport?: boolean;
     };
   },
   loggerInstance = logger,
@@ -89,7 +91,7 @@ export async function handleAgentRequest(
   // Extract request ID from headers
   const requestId = data.headers?.["x-request-id"] || crypto.randomUUID();
   const childLogger = loggerInstance.child({ requestId });
-  const { text, imageUrl, caption, model, findSimilar } = data.body;
+  const { text, imageUrl, caption, model, findSimilar, isReport } = data.body;
   let agentRequest: AgentRequest;
   if (text) {
     agentRequest = {
@@ -119,6 +121,9 @@ export async function handleAgentRequest(
     agentRequest.findSimilar = false;
   } else {
     agentRequest.findSimilar = true;
+  }
+  if (isReport) {
+    agentRequest.isReport = true;
   }
 
   try {

--- a/workers/api-entrypoint/src/endpoints/agentCheckV2.ts
+++ b/workers/api-entrypoint/src/endpoints/agentCheckV2.ts
@@ -37,6 +37,7 @@ export const agentRequestSchemaV2 = {
             // Common properties
             model: z.string().optional(),
             findSimilar: z.boolean().optional(),
+            isReport: z.boolean().optional(),
           })
           .describe(
             "Request body schema. For text, pass 'text' only. For image, pass 'imageUrl' or 'caption'. Leave 'model' blank for default."
@@ -81,6 +82,7 @@ export async function handleAgentRequest(
       caption?: string | null;
       model?: string;
       findSimilar?: boolean;
+      isReport?: boolean;
     };
   },
   loggerInstance = logger,
@@ -89,7 +91,7 @@ export async function handleAgentRequest(
   // Extract request ID from headers
   const requestId = data.headers?.["x-request-id"] || crypto.randomUUID();
   const childLogger = loggerInstance.child({ requestId });
-  const { text, imageUrl, caption, model, findSimilar } = data.body;
+  const { text, imageUrl, caption, model, findSimilar, isReport } = data.body;
   let agentRequest: AgentRequest;
   if (text) {
     agentRequest = {
@@ -119,6 +121,9 @@ export async function handleAgentRequest(
     agentRequest.findSimilar = false;
   } else {
     agentRequest.findSimilar = true;
+  }
+  if (isReport) {
+    agentRequest.isReport = true;
   }
 
   try {


### PR DESCRIPTION
## Summary
- Add optional `isReport` boolean field to `AgentRequest` and `Check` types
- Pass `isReport` through API entrypoint (v1 and v2) to agent-service and persist to MongoDB check records
- Include `isReport` in poll creation payload
- Align `ai-checker-service` check record fields (`notificationId`, `communityNoteNotificationId`, `isReport`) with `agent-service`

## Test plan
- [ ] Submit a check request with `isReport: true` and verify the field is persisted in the DB
- [ ] Submit without `isReport` and verify it defaults to `false`
- [ ] Verify poll creation receives the `isReport` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)