### PR TITLE
fix: stringify pollId ObjectId on check reads to fix RPC serialization

### DIFF
--- a/workers/database-service/src/index.ts
+++ b/workers/database-service/src/index.ts
@@ -12,6 +12,17 @@ import { Check, Submission } from "@workspace/shared-types";
 // Shared logger
 const logger = createLogger("database-service");
 
+// Convert a raw Mongo check document into a Check safe to send over RPC.
+// Workers RPC structured-clone rejects ObjectId, so every ObjectId-typed
+// field on the document must be stringified before returning.
+function serializeCheck(check: Record<string, any>): Check {
+  return {
+    ...check,
+    _id: check._id.toString(),
+    pollId: check.pollId ? check.pollId.toString() : null,
+  } as Check;
+}
+
 /**
  * DatabaseDurableObject maintains a persistent MongoDB connection
  * This significantly improves performance by avoiding connection overhead
@@ -76,13 +87,9 @@ export class DatabaseDurableObject extends DurableObject<Env> {
         };
       }
 
-      // Convert _id to string for the external interface
       return {
         success: true,
-        data: {
-          ...check,
-          _id: check._id.toString(),
-        } as Check,
+        data: serializeCheck(check),
       };
     } catch (error) {
       const errorMessage =
@@ -111,13 +118,9 @@ export class DatabaseDurableObject extends DurableObject<Env> {
         };
       }
 
-      // Convert _id to string for the external interface
       return {
         success: true,
-        data: {
-          ...check,
-          _id: check._id.toString(),
-        } as Check,
+        data: serializeCheck(check),
       };
     } catch (error) {
       const errorMessage =
@@ -161,13 +164,9 @@ export class DatabaseDurableObject extends DurableObject<Env> {
         };
       }
 
-      // Convert _id to string for the external interface
       return {
         success: true,
-        data: {
-          ...check,
-          _id: check._id.toString(),
-        } as Check,
+        data: serializeCheck(check),
       };
     } catch (error) {
       const errorMessage =


### PR DESCRIPTION
## Summary

- Adds a `serializeCheck()` helper in `workers/database-service/src/index.ts` that stringifies both `_id` and `pollId`, and applies it to `findCheckById`, `findCheckByTextHash`, `findCheckByImageHash`.
- Fixes a production crash where `agent-service` would fail with `Could not serialize object of type "_ObjectId"` whenever similar-check lookup matched a legacy document with a Mongo `ObjectId`-typed `pollId`.

## Why this bug happened

Some legacy check documents in MongoDB store `pollId` as an `ObjectId` (written by an older code path before #102 / commit 30b1321). Workers RPC structured-clone rejects `ObjectId`, so when `agent-service` called `DATABASE_SERVICE.findCheckById` and the matched document had such a `pollId`, the RPC threw — killing the agent's `check()` flow *before* `insertSubmission` or `insertCheck` ran. That's why affected requests never created a submission or check in MongoDB.

Confirmed via Cloudflare observability logs (requestId `5GEBDPXYCVOKHSBV`): trace ended at `Getting check` → `Could not serialize object of type "_ObjectId"` → `outcome: canceled`.

Within this repo all writers now persist `pollId` as a string (or null), so this is purely a read-side defensive fix for the stock of legacy docs (which has separately been backfilled by a one-shot Mongo migration).

## Test plan

- [ ] Re-trigger a request that previously matched the offending check (`_id: 694a27cb4fdd4bd4e56efa6e`) and confirm:
  - [ ] agent-service no longer logs `Could not serialize object of type "_ObjectId"`
  - [ ] api-entrypoint returns a 200 with the existing check result
  - [ ] A new submission row is created in Mongo
- [ ] Sanity-check non-matching submissions still complete the full agent flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)