### PR TITLE
2.0.14

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "cloudflare@claude-plugins-official": true
+  }
+}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,44 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -36,9 +36,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/workers/database-service/src/index.ts
+++ b/workers/database-service/src/index.ts
@@ -12,6 +12,17 @@ import { Check, Submission } from "@workspace/shared-types";
 // Shared logger
 const logger = createLogger("database-service");
 
+// Convert a raw Mongo check document into a Check safe to send over RPC.
+// Workers RPC structured-clone rejects ObjectId, so every ObjectId-typed
+// field on the document must be stringified before returning.
+function serializeCheck(check: Record<string, any>): Check {
+  return {
+    ...check,
+    _id: check._id.toString(),
+    pollId: check.pollId ? check.pollId.toString() : null,
+  } as Check;
+}
+
 /**
  * DatabaseDurableObject maintains a persistent MongoDB connection
  * This significantly improves performance by avoiding connection overhead
@@ -76,13 +87,9 @@ export class DatabaseDurableObject extends DurableObject<Env> {
         };
       }
 
-      // Convert _id to string for the external interface
       return {
         success: true,
-        data: {
-          ...check,
-          _id: check._id.toString(),
-        } as Check,
+        data: serializeCheck(check),
       };
     } catch (error) {
       const errorMessage =
@@ -111,13 +118,9 @@ export class DatabaseDurableObject extends DurableObject<Env> {
         };
       }
 
-      // Convert _id to string for the external interface
       return {
         success: true,
-        data: {
-          ...check,
-          _id: check._id.toString(),
-        } as Check,
+        data: serializeCheck(check),
       };
     } catch (error) {
       const errorMessage =
@@ -161,13 +164,9 @@ export class DatabaseDurableObject extends DurableObject<Env> {
         };
       }
 
-      // Convert _id to string for the external interface
       return {
         success: true,
-        data: {
-          ...check,
-          _id: check._id.toString(),
-        } as Check,
+        data: serializeCheck(check),
       };
     } catch (error) {
       const errorMessage =


### PR DESCRIPTION
## Summary

Release **2.0.14** rolls up two independent change sets from `staging`:

1. **Bug fix** — `database-service` now defensively stringifies legacy `pollId` ObjectIds so similar-check lookups don't crash agent-service over RPC.
2. **Tooling** — GitHub Actions for Claude Code (PR review + `@claude` mentions) and project-scoped plugin config.

## Changes

### 1. `workers/database-service/src/index.ts` — pollId ObjectId serialization fix (#114)

Some legacy check documents in MongoDB store `pollId` as a Mongo `ObjectId` (written by an older code path before #102 / commit `30b1321`). When `agent-service` called `DATABASE_SERVICE.findCheckById` over Workers RPC, structured-clone rejected the ObjectId and threw `Could not serialize object of type "_ObjectId"`. This killed the agent's `check()` flow **before** `insertSubmission` / `insertCheck` ran, so affected requests silently disappeared (no submission, no check, caller saw a 500). Confirmed via Cloudflare observability logs.

The fix introduces a `serializeCheck()` helper at the top of `workers/database-service/src/index.ts` that stringifies both `_id` and `pollId`, and replaces the three inline spreads in `findCheckById`, `findCheckByTextHash`, and `findCheckByImageHash` with that helper. Writers within this repo already persist `pollId` as a string, so this is a defensive read-side fix for the legacy stock; that stock has also been backfilled in Mongo separately.

### 2. `.github/workflows/claude.yml` — Claude PR Assistant (#115)

New workflow that runs `anthropics/claude-code-action@v1` whenever someone mentions `@claude` in:
- a PR comment
- a PR review comment / review body
- an issue body or title (on open/assign)

Uses `secrets.CLAUDE_CODE_OAUTH_TOKEN`. Has `contents: read`, `pull-requests: read`, `issues: read`, `id-token: write`, `actions: read` permissions (the last so Claude can read CI results on PRs).

### 3. `.github/workflows/claude-code-review.yml` — Automatic PR code review (#115)

New workflow that runs Claude's `code-review` plugin against every PR on `opened`, `synchronize`, `ready_for_review`, `reopened`. Posts findings as inline PR comments via `/code-review:code-review --comment ...`. Has `pull-requests: write` so it can post the review. Path/author filters are commented-out placeholders for now (runs on every PR from every author).

### 4. `.claude/settings.json` — project-scoped Claude Code config (#115)

New file enabling the `cloudflare@claude-plugins-official` plugin at project scope so contributors using Claude Code in this repo get the Cloudflare skill set auto-loaded.

## Test plan

- [ ] Re-trigger a request that previously matched a check with `pollId` stored as ObjectId (e.g. `_id: 694a27cb4fdd4bd4e56efa6e`) on production and verify:
  - [ ] `agent-service` no longer logs `Could not serialize object of type "_ObjectId"` in Cloudflare observability
  - [ ] `api-entrypoint` returns 200 with the cached check result
  - [ ] A new submission row is created in Mongo
- [ ] Open a throwaway PR and confirm:
  - [ ] `Claude Code Review` workflow runs and posts inline review comments
  - [ ] Tagging `@claude` in a PR comment triggers the `Claude Code` workflow
- [ ] Sanity-check non-matching submissions still complete the full agent flow end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)